### PR TITLE
BLOC-11_open-source-torrent-server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-- '0.12'
-- 'iojs-v2.0.1'
+- 'node'
+- '4.6.1'
 before_script:
 - npm install -g istanbul
 - npm install -g mocha

--- a/README.md
+++ b/README.md
@@ -50,8 +50,6 @@ var properties = {
   folders: { // Folder structure settings
     torrents: '/torrents',  // Path to save torrent files to, if left empty, all the torrent references will be saved in memory and will be lost on restart
     data: '/data',          // Main path to where all the data is stored
-    spvData: '/spv',        // Path to where data that is relevent to us is stored relative to the main path
-    fullNodeData: '/full',  // Path to where data that is not relevent to us is stored relative to the main path
     capSize: '80%',          // Number of MB or percent in the form of 12%
     retryTime: 10000,
     autoWatchInterval: 60000,

--- a/README.md
+++ b/README.md
@@ -65,15 +65,13 @@ var handler = new MetadataHandler(settings)
 Params:
   - torrentHash - The torrent infoHash of the metadata.
   - metadataSHA2 - The sha256 of the metadata json.
-  - importent - A boolean flag which determines if the metadata will be saved forever or possibly deleted when folder reaches max limit size.
 
 ```js
 
 var torrentHash = '5add2b0ce8f7da372c856d4efe6b9b6e8584919e'
 var metadataSHA2 = '6ed0dd02806fa89e25de060c19d3ac86cabb87d6a0ddd05c333b84f4'
-var importent = true
 
-handler.getMetadata(torrentHash, metadataSHA2, importent, function (err, metadata) {
+handler.getMetadata(torrentHash, metadataSHA2, function (err, metadata) {
   if (err) return console.error(err)
   console.log(metadata) // Will print the json file of the metadata
 })
@@ -107,7 +105,7 @@ Params:
 // Returns the torrentHash and sha2 created.
 handler.addMetadata(metadata, function (err, hashes) {
   if (err) return console.error(err)
-  console.log(hashes.torrentHash) // Will print Bit-torrent hashing scheme using sha1 as the hashing algorithem
+  console.log(hashes.torrentHash) // Will print BitTorrent hashing scheme using sha1 as the hashing algorithem
   console.log(hashes.sha2) // Will print the sha256 of the raw metadata file
 })
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,22 @@ handler.shareMetadata(torrentHash, function (err) {
 
 ```
 
+### Remove Metadata
+
+Remove torrent from BitTorrent client. Destroy all torrent connections to peers, delete all saved data.
+
+Params:
+  - torrentHash - The torrent info hash of the metadata we want to remove 
+
+```js
+
+handler.removeMetadata(torrentHash, function (err) {
+  if (err) throw err
+  console.log('successfully deleted torrent')
+})
+
+```
+
 ### Other Events
 
 ```js

--- a/index.js
+++ b/index.js
@@ -181,7 +181,6 @@ MetadataHandler.prototype.shareMetadata = function (infoHash, cb) {
     }
     self.client.on('error', function (err) {console.error(err)})
     self.client.seed(dataFilePath, opts, function (torrent) {
-      // console.log('onseed() - torrent.infoHash = ', torrent.infoHash)
       self.emit('uploads/' + infoHash, torrent)
       self.emit('uploads', torrent)
       if (cb) cb(null, torrent)
@@ -192,7 +191,6 @@ MetadataHandler.prototype.shareMetadata = function (infoHash, cb) {
 MetadataHandler.prototype.removeMetadata = function (infoHash, cb) {
   var self = this
   var torrentFilePath = self.torrentDir + '/' + infoHash + '.torrent'
-  // console.log('removeMetadata: client.torrents =', self.client.torrents)
   async.auto({
     removeTorrentFromClient: function (cb) {
       self.client.remove(infoHash, cb)

--- a/index.js
+++ b/index.js
@@ -79,7 +79,6 @@ var createTorrentFromMetaData = function (params, cb) {
     urlList: params.urlList,            // web seed urls (see [bep19](http://www.bittorrent.org/beps/bep_0019.html))
     pieceLength: params.pieceLength     // force a custom piece length (number of bytes)
   }
-  console.log('opts', JSON.stringify(opts))
   createTorrent(params.filePath, opts, function (err, torrent) {
     if (err) return cb(err)
     var torrentObject = parseTorrent(torrent)

--- a/package.json
+++ b/package.json
@@ -7,14 +7,14 @@
     "async": "^1.5.2",
     "better-console": "^0.2.4",
     "cli-table": "^0.3.1",
-    "create-torrent": "git+https://github.com/oleiba/create-torrent.git#allow_empty_announce",
+    "create-torrent": "3.12.0",
     "crypto-hashing": "^0.3.1",
     "folder-capper": "^0.2.1",
     "graceful-fs": "^4.1.2",
     "lodash": "^3.9.3",
     "moment": "^2.10.3",
     "parse-torrent": "^4.1.0",
-    "webtorrent": "0.95.2"
+    "webtorrent": "git+https://github.com/oleiba/webtorrent.git#0.78.0-create-torrent@3.12"
   },
   "scripts": {
     "test": "mocha",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "graceful-fs": "^4.1.2",
     "lodash": "^3.9.3",
     "moment": "^2.10.3",
-    "parse-torrent": "^4.1.0",
-    "webtorrent": "git+https://github.com/oleiba/webtorrent.git#0.78.0-create-torrent@3.12"
+    "parse-torrent": "^5.1.0",
+    "webtorrent": "git+https://github.com/oleiba/webtorrent.git#0.95.2-create-torrent@3.12"
   },
   "scripts": {
     "test": "mocha",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lodash": "^3.9.3",
     "moment": "^2.10.3",
     "parse-torrent": "^5.1.0",
-    "webtorrent": "git+https://github.com/oleiba/webtorrent.git#0.95.2-create-torrent@3.12"
+    "webtorrent": "git+https://github.com/oleiba/webtorrent.git#0.78.1-create-torrent@3.12"
   },
   "scripts": {
     "test": "mocha",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lodash": "^3.9.3",
     "moment": "^2.10.3",
     "parse-torrent": "^4.1.0",
-    "webtorrent": "0.78.0"
+    "webtorrent": "0.95.2"
   },
   "scripts": {
     "test": "mocha",

--- a/test/test.js
+++ b/test/test.js
@@ -29,8 +29,6 @@ var properties = {
   folders: {
     torrents: './torrents',
     data: './data',
-    spvData: '/spv',
-    fullNodeData: '/full',
     capSize: '80%',
     retryTime: 10000,
     autoWatchInterval: 60000,
@@ -41,8 +39,6 @@ var properties = {
 var folders = []
 folders.push(properties.folders.torrents)
 folders.push(properties.folders.data)
-folders.push(properties.folders.data + properties.folders.spvData)
-folders.push(properties.folders.data + properties.folders.fullNodeData)
 folders.forEach(function (dir) {
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir)


### PR DESCRIPTION
- Use a forked version of [WebTorrent  v0.78.1](https://github.com/feross/webtorrent/tree/v0.78.1):
    - keeps backward compatible torrent-hashes from metadata JSONs
    - fixes issues with removing a torrent
- Add `removeMetadata`
- Some API cleanup.
- Drop support for Node < 4

Candidate for v0.6.0.