### PR TITLE
Fix "torrent is destroyed" exception on Colored-Coins-Metadata-Server (#2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,14 +7,14 @@
     "async": "^1.5.2",
     "better-console": "^0.2.4",
     "cli-table": "^0.3.1",
-    "create-torrent": "3.12.0",
+    "create-torrent": "^3.24.5",
     "crypto-hashing": "^0.3.1",
     "folder-capper": "^0.2.1",
     "graceful-fs": "^4.1.2",
     "lodash": "^3.9.3",
     "moment": "^2.10.3",
     "parse-torrent": "^5.1.0",
-    "webtorrent": "git+https://github.com/oleiba/webtorrent.git#0.78.1-create-torrent@3.12"
+    "webtorrent": "^0.98.19"
   },
   "scripts": {
     "test": "mocha",


### PR DESCRIPTION
Update webtorrent package to its latest version to fix “torrent is destroyed” exception that is thrown when running the Colored-Coins-Metadata-Server (which consumes this package) with seeding enabled. The create-torrent package is also being updated to match the version used by the updated version of the webtorrent package.